### PR TITLE
Add next page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { settingsActions } from './store/settings-slice';
 // import { useDispatch } from 'react-redux';
 import { coursesActions } from './store/courses-slice';
 import { getTimetable } from './store/timetable-action';
+import { getPages } from './store/pages-action';
 import { useDispatch, useTypedSelector } from './store';
 
 
@@ -119,6 +120,7 @@ function App() {
   useEffect(() => {
     dispatch(settingsActions.fetchSettings("iphone"))
     dispatch(coursesActions.fetchCourses())
+    dispatch(getPages())
     dispatch(getTimetable())
 
   }, [dispatch])

--- a/src/components/Menu/ColorRadioSelection/ColorRadioSelection.tsx
+++ b/src/components/Menu/ColorRadioSelection/ColorRadioSelection.tsx
@@ -18,7 +18,7 @@ export default function ColorRadioSelection(props: ColorRadioSelectionProps) {
 
     return (
         <>
-            <div>
+            <div style={{ display: "flex", flexDirection: "row", justifyContent: "center", alignItems: "center" }}>
                 <p>Text Color</p>
                 {
                     props.options.map(color => {

--- a/src/components/Menu/CourseInfoForm/CourseInfoForm.tsx
+++ b/src/components/Menu/CourseInfoForm/CourseInfoForm.tsx
@@ -91,10 +91,10 @@ export default function CourseInfoForm(props: courseInfo) {
 
         for (const meetingTime of meetingTimes) {
 
-            if (meetingTime.startTime < startTime) {
-                setErrorMessage("Course start time is earlier than timetable start time")
-                return true
-            }
+            // if (meetingTime.startTime < startTime) {
+            //     setErrorMessage("Course start time is earlier than timetable start time")
+            //     return true
+            // }
 
             if (meetingTime.startTime > meetingTime.endTime) {
                 setErrorMessage("Course start time is earlier than course end time")

--- a/src/components/Menu/CourseInfoForm/CourseInfoForm.tsx
+++ b/src/components/Menu/CourseInfoForm/CourseInfoForm.tsx
@@ -59,7 +59,6 @@ export default function CourseInfoForm(props: courseInfo) {
 
 
     function handleAddMeetingTime() {
-        console.log("Add MeetingTime Render")
         setMeetingTimeSchedules(prev => {
             const newMeetingTime = generateEmptyMeetingTime();
             return [...prev, newMeetingTime]

--- a/src/components/Menu/DownloadButton/DownloadButton.tsx
+++ b/src/components/Menu/DownloadButton/DownloadButton.tsx
@@ -17,13 +17,11 @@ interface DownloadButtonProps {
 
 export default function DownloadButton(props: DownloadButtonProps) {
     const backgroundColor = useSelector((state: RootState) => state.settings.backgroundColor)
-    console.log(backgroundColor)
 
     function handleDownload() {
         const input = document.getElementById("TimetableBackground");
 
         if (input) {
-            console.log(input)
             html2canvas(input!, {
                 scale: 4,
                 backgroundColor: backgroundColor,

--- a/src/components/Menu/Inputs/Widgets/Widgets.tsx
+++ b/src/components/Menu/Inputs/Widgets/Widgets.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import ToggleButton from "@mui/material/ToggleButton"
+import ToggleButtonGroup from "@mui/material/ToggleButtonGroup"
+import Typography from "@mui/material/Typography"
+
+interface WidgetsProps {
+    value: boolean,
+    handleChange: (value: boolean) => void
+}
+
+export default function Widgets(props: WidgetsProps) {
+
+    function handleWidgetsChange(event: React.MouseEvent<HTMLElement>, newWidgets: boolean) {
+        props.handleChange(newWidgets)
+    }
+    return (
+        <div style={{ display: "flex", flexDirection: "row", justifyContent: "center", alignItems: "center" }}>
+
+            <Typography variant="body1">Widgets:</Typography>
+
+            <ToggleButtonGroup aria-label="hour formatting" color="info" value={props.value}>
+                <ToggleButton value={true} aria-label="yes" onClick={handleWidgetsChange}>Yes</ToggleButton>
+                <ToggleButton value={false} aria-label="yes" onClick={handleWidgetsChange}>No</ToggleButton>
+
+            </ToggleButtonGroup>
+        </div>
+    )
+}

--- a/src/components/Menu/MenuItems/MenuItems.tsx
+++ b/src/components/Menu/MenuItems/MenuItems.tsx
@@ -34,7 +34,6 @@ export default function MenuItems() {
 
     useEffect(() => {
         dispatch(coursesActions.fetchCourses())
-        console.log("dispatch")
     }, [dispatch])
 
 

--- a/src/components/Menu/Setting/Setting.tsx
+++ b/src/components/Menu/Setting/Setting.tsx
@@ -17,8 +17,10 @@ import DisplayTime from "../Inputs/DisplayTime";
 import { settingsActions } from "../../../store/settings-slice";
 import { RootState, useDispatch } from "../../../store/index"
 import { getTimetable } from "../../../store/timetable-action";
+import Widgets from "../Inputs/Widgets/Widgets";
 
 import ColorRadioSelection from "../ColorRadioSelection/ColorRadioSelection";
+import { getPages } from "../../../store/pages-action";
 
 
 export default function Setting() {
@@ -34,6 +36,7 @@ export default function Setting() {
     const courseGridHeight = useSelector((state: RootState) => state.settings.courseGridHeight)
     const clockType = useSelector((state: RootState) => state.settings.clockType)
     const displayTime = useSelector((state: RootState) => state.settings.displayTime)
+    const widgets = useSelector((state: RootState) => state.settings.widgets)
 
     const [errorMessage, setErrorMessage] = useState<string>('')
 
@@ -56,7 +59,6 @@ export default function Setting() {
 
     function handleTextColorChange(value: string) {
         dispatch(settingsActions.setTextColor(value))
-        console.log(value)
     }
 
     function handleStartTimeChange(value: Dayjs | null) {
@@ -82,13 +84,15 @@ export default function Setting() {
     }
 
     function handleClockTypeChange(value: "12 Hour" | "24 Hour") {
-        console.log(value)
         dispatch(settingsActions.setClockType(value))
     }
 
     function handleDisplayTimeChange(value: boolean) {
-        console.log(value)
         dispatch(settingsActions.setDisplayTime(value))
+    }
+
+    function handleWidgetsChange(value: boolean) {
+        dispatch(settingsActions.setWidgets(value))
     }
 
     function resetToDefault() {
@@ -108,6 +112,7 @@ export default function Setting() {
             return
         }
         dispatch(settingsActions.sendSettings())
+        dispatch(getPages())
         dispatch(getTimetable())
     }
 
@@ -144,6 +149,8 @@ export default function Setting() {
                 <ClockType value={clockType} handleChange={handleClockTypeChange} />
 
                 <DisplayTime value={displayTime} handleChange={handleDisplayTimeChange} />
+
+                <Widgets value={widgets} handleChange={handleWidgetsChange} />
 
                 <Button variant="outlined" color="info" onClick={resetToDefault}>Reset to default</Button>
 

--- a/src/components/Timetable/CourseGrid/CourseGrid.tsx
+++ b/src/components/Timetable/CourseGrid/CourseGrid.tsx
@@ -12,6 +12,8 @@ export interface CourseGridInfos {
     location: string;
     startTime: Dayjs;
     endTime: Dayjs;
+    displayStartTime: Dayjs;
+    displayEndTime: Dayjs;
     height: number;
 }
 

--- a/src/components/Timetable/Timetable.tsx
+++ b/src/components/Timetable/Timetable.tsx
@@ -23,9 +23,15 @@ function generateHours(startTime: Dayjs, endTime: Dayjs) {
 }
 
 export default function Timetable() {
-    const timetable = useSelector((state: RootState) => state.timetable)
-    const startTime = useSelector((state: RootState) => state.settings.startTime)
-    const endTime = useSelector((state: RootState) => state.settings.endTime)
+    // const startTime = useSelector((state: RootState) => state.settings.startTime)
+    // const endTime = useSelector((state: RootState) => state.settings.endTime)
+    const currPage = useSelector((state: RootState) => state.pages.currPage)
+    const startTime = useSelector((state: RootState) => state.pages.pages[currPage - 1].startTime)
+    const endTime = useSelector((state: RootState) => state.pages.pages[currPage - 1].endTime)
+    // console.log("Timetable start time" + startTime.hour())
+    // console.log("Timetable end time" + endTime.hour())
+    const timetable = useSelector((state: RootState) => state.timetable[currPage - 1])
+
     const backgroundColor = useSelector((state: RootState) => state.settings.backgroundColor)
     const headerColor = useSelector((state: RootState) => state.settings.headerColor)
     const textColor = useSelector((state: RootState) => state.settings.textColor)
@@ -55,7 +61,6 @@ export default function Timetable() {
                         </tr>
 
                         {hours.map(time => (
-
                             <tr className={TimetableCSS.tr} key={time.hour()} style={{ height: courseGridHeight, borderColor: textColor }}>
                                 <th className={TimetableCSS.th} style={{ backgroundColor: headerColor, width: 32, borderColor: textColor }}>{clockType === "12 Hour" ? time.format("hh:mm \n A") : time.format("HH:mm")}</th>
                                 {Object.keys(timetable).map((day) => {

--- a/src/components/Timetable/TimetableTd/TimetableTd.tsx
+++ b/src/components/Timetable/TimetableTd/TimetableTd.tsx
@@ -19,7 +19,7 @@ export default function TimetableTd(props: timetableTdProps) {
     const textColor = useSelector((state: RootState) => state.settings.textColor)
 
     function calculateTop(index: number) {
-        const startTime = props.courseGridInfos![index].startTime;
+        const startTime = props.courseGridInfos![index].displayStartTime;
         const timeDiff = startTime.diff(props.time, 'hour', true)
 
         return timeDiff

--- a/src/components/Timetable/TimetableTd/TimetableTd.tsx
+++ b/src/components/Timetable/TimetableTd/TimetableTd.tsx
@@ -25,8 +25,6 @@ export default function TimetableTd(props: timetableTdProps) {
         return timeDiff
     }
 
-    console.log("courseGridWidth" + courseGridWidth)
-
     return (
         <>
             <td className={TimetableTdCSS.td} rowSpan={props.rowspan} style={{ width: courseGridWidth, borderColor: textColor }}>

--- a/src/components/Timetable/timetable.module.css
+++ b/src/components/Timetable/timetable.module.css
@@ -25,7 +25,11 @@
 }
 
 .iphone .table {
-    bottom: 80px;
+    /* bottom: 80px; */
+    /* without widgets */
+    /* top: 234px; */
+    /* with widgets */
+    top: 299px;
 }
 
 .ipad .table {

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -1,0 +1,2 @@
+export const IPHONE_LENGTH_LIMIT = 441;
+export const IPAD_LENGTH_LIMIT = 405;

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -1,2 +1,3 @@
 export const IPHONE_LENGTH_LIMIT = 441;
+export const IPHONE_WITH_WIDGETS_LENGTH_LIMIT = 376;
 export const IPAD_LENGTH_LIMIT = 405;

--- a/src/interfaces/pagesInterfaces.ts
+++ b/src/interfaces/pagesInterfaces.ts
@@ -1,0 +1,14 @@
+import { Dayjs } from 'dayjs';
+
+export interface Pages {
+    pageNumber: number,
+    startTime: Dayjs,
+    endTime: Dayjs
+}
+
+export interface PagesState {
+    numberOfPages: number,
+    currPage: number,
+    pages: Pages[]
+}
+

--- a/src/interfaces/settingsInterfaces.ts
+++ b/src/interfaces/settingsInterfaces.ts
@@ -21,6 +21,7 @@ export interface TimetableSettings {
     courseGridWidth: number,
     courseGridHeight: number,
     clockType: '12 Hour' | '24 Hour',
-    displayTime: boolean
+    displayTime: boolean,
+    widgets: boolean,
 }
 

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -4,6 +4,8 @@ import Navbar from "../../components/Navbar";
 import Footer from "../../components/Footer/Footer";
 import MenuItems from "../../components/Menu/MenuItems/MenuItems";
 import Device from "../../components/Device/Device";
+import IconButton from "@mui/material/IconButton";
+import NavigateNextIcon from '@mui/icons-material/NavigateNext';
 
 
 export default function Home() {
@@ -21,6 +23,10 @@ export default function Home() {
                         display="flex"
                     >
                         <Device />
+                        <IconButton>
+                            <NavigateNextIcon />
+
+                        </IconButton>
 
                     </Grid>
 

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -6,9 +6,21 @@ import MenuItems from "../../components/Menu/MenuItems/MenuItems";
 import Device from "../../components/Device/Device";
 import IconButton from "@mui/material/IconButton";
 import NavigateNextIcon from '@mui/icons-material/NavigateNext';
+import NavigateBeforeIcon from '@mui/icons-material/NavigateBefore';
+import { useDispatch } from "react-redux";
+import { pagesActions } from "../../store/pages-slice";
 
 
 export default function Home() {
+    const dispatch = useDispatch()
+
+    function handlePrevPage() {
+        dispatch(pagesActions.prevPage())
+    }
+
+    function handleNextPage() {
+        dispatch(pagesActions.nextPage())
+    }
 
     return (
         <>
@@ -18,12 +30,17 @@ export default function Home() {
 
                 <Grid container direction="row" sx={{ minHeight: "780px" }}>
 
+
                     <Grid item xs={12} md={8.5}
                         justifyContent="center"
                         display="flex"
+                        alignItems="center"
                     >
+                        <IconButton onClick={handlePrevPage} sx={{ height: "40px", width: "40px" }}>
+                            <NavigateBeforeIcon />
+                        </IconButton>
                         <Device />
-                        <IconButton>
+                        <IconButton onClick={handleNextPage} sx={{ height: "40px", width: "40px" }}>
                             <NavigateNextIcon />
 
                         </IconButton>

--- a/src/store/courses-slice.ts
+++ b/src/store/courses-slice.ts
@@ -12,31 +12,25 @@ const coursesSlice = createSlice({
     reducers: {
         addCourse(state, action) {
             const newCourse = action.payload
-            console.log("addCourse")
 
             if (newCourse.existed) {
                 const index = state.findIndex((oldCourse: courseInfo) => oldCourse.id === newCourse.id)
                 state[index] = Object.assign({}, state[index], newCourse)
             } else {
                 state.push(newCourse)
-                console.log("after state")
             }
 
             localStorage.setItem("courses", JSON.stringify(state))
         },
         removeCourse(state, action) {
-            console.log("removeCourse")
             const index = state.findIndex((course: courseInfo) => course.id === action.payload)
-            console.log(index)
             state.splice(index, 1)
             localStorage.setItem("courses", JSON.stringify(state))
         },
         fetchCourses(state) {
-            console.log("fetch courses")
             const localCourses = localStorage.getItem("courses")
             if (localCourses) {
                 const courses: courseInfo[] = JSON.parse(localCourses)
-                console.log("localCourses" + courses)
                 for (const course of courses) {
                     for (const meetingTime of course.meetingTimes) {
                         meetingTime.startTime = dayjs(meetingTime.startTime)

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -2,16 +2,22 @@ import { configureStore } from "@reduxjs/toolkit"
 import settingsReducer from "./settings-slice"
 import coursesReducer from "./courses-slice"
 import timetableReducer from "./timetable-slice"
+import pagesReducer from "./pages-slice"
 import thunk from 'redux-thunk';
 import { useDispatch as useReduxDispatch, useSelector, TypedUseSelectorHook } from 'react-redux';
 
 export interface UpdateTimetableAction {
     type: string;
-    payload: any; // Replace with your actual payload type
+    payload: any;
+}
+
+export interface SetPagesAction {
+    type: string;
+    payload: any;
 }
 
 const store = configureStore({
-    reducer: { settings: settingsReducer, courses: coursesReducer, timetable: timetableReducer },
+    reducer: { settings: settingsReducer, courses: coursesReducer, timetable: timetableReducer, pages: pagesReducer },
     middleware: getDefaultMiddleware =>
         getDefaultMiddleware({
             serializableCheck: false,

--- a/src/store/pages-action.ts
+++ b/src/store/pages-action.ts
@@ -1,0 +1,72 @@
+import { RootState } from ".";
+import { ThunkAction } from 'redux-thunk';
+import { pagesActions } from "./pages-slice";
+import { SetPagesAction } from "./index";
+import { IPAD_LENGTH_LIMIT, IPHONE_LENGTH_LIMIT, IPHONE_WITH_WIDGETS_LENGTH_LIMIT } from "../data/constants"
+
+
+function setTheLimit(device: string, widgets: boolean): number {
+    if (device === "iphone" && widgets) {
+        return IPHONE_WITH_WIDGETS_LENGTH_LIMIT;
+    } else if (device === "iphone" && !widgets) {
+        return IPHONE_LENGTH_LIMIT;
+    } else if (device === "ipad") {
+        return IPAD_LENGTH_LIMIT;
+    } else {
+        return IPHONE_LENGTH_LIMIT;
+    }
+}
+
+function generatePages(startTime: any, endTime: any, numberOfRows: number): any {
+    let pages = []
+
+    const page1 = {
+        pageNumber: 1,
+        startTime: startTime,
+        endTime: startTime.add(numberOfRows, 'hour')
+    }
+    pages.push(page1)
+
+    const page2 = {
+        pageNumber: 2,
+        startTime: startTime.add(numberOfRows, 'hour'),
+        endTime: endTime
+    }
+    pages.push(page2)
+
+    return pages
+}
+
+export const getPages = (): ThunkAction<void, RootState, void, SetPagesAction> => {
+    return (dispatch, getState) => {
+        const state = getState();
+        const device = state.settings.device;
+        const startTime = state.settings.startTime;
+        const endTime = state.settings.endTime;
+        const courseGridHeight = state.settings.courseGridHeight;
+        const widgets = state.settings.widgets;
+
+        console.log("get pages called")
+
+        // 1. Set the limit
+        let limit = setTheLimit(device, widgets)
+
+        // 2. Calculate number of rows
+        const numberOfRows = Math.floor(limit / courseGridHeight)
+
+        // 3. Calculate number of pages startTime and endTime
+        const numberOfPages = Math.ceil((endTime.diff(startTime, 'hour', true)) / numberOfRows)
+
+        //4. Generate pages
+        let pages = generatePages(startTime, endTime, numberOfRows)
+
+        const pagesInfo = {
+            numberOfPages: numberOfPages,
+            currPage: 1,
+            pages: pages
+        }
+
+        dispatch(pagesActions.setPages(pagesInfo));
+
+    }
+}

--- a/src/store/pages-slice.ts
+++ b/src/store/pages-slice.ts
@@ -1,0 +1,41 @@
+import { createSlice } from "@reduxjs/toolkit"
+import dayjs from "dayjs"
+
+
+const initialState = {
+    numberOfPages: 1,
+    currPage: 1,
+    pages: [
+        {
+            pageNumber: 1,
+            startTime: dayjs('2022-04-17T09:00'),
+            endTime: dayjs('2022-04-17T18:00'),
+        }
+    ]
+}
+
+
+const pagesSlice = createSlice({
+    name: "pages",
+    initialState,
+    reducers: {
+        setPages(state, action) {
+            return action.payload
+        },
+        nextPage(state) {
+            if (state.currPage < state.numberOfPages) {
+                state.currPage += 1
+            }
+        },
+        prevPage(state) {
+            if (state.currPage > 1) {
+                state.currPage -= 1
+            }
+        }
+
+    }
+})
+
+export const pagesActions = pagesSlice.actions
+
+export default pagesSlice.reducer

--- a/src/store/settings-slice.ts
+++ b/src/store/settings-slice.ts
@@ -24,7 +24,8 @@ const initialIphoneState: TimetableSettings = {
     courseGridWidth: 49,
     courseGridHeight: 49,
     clockType: '12 Hour',
-    displayTime: true
+    displayTime: true,
+    widgets: true
 }
 
 const initialIpadDays = {
@@ -48,7 +49,8 @@ const initialIpadState: TimetableSettings = {
     courseGridWidth: 90,
     courseGridHeight: 44,
     clockType: '12 Hour',
-    displayTime: true
+    displayTime: true,
+    widgets: true
 }
 
 const settingsSlice = createSlice({
@@ -56,7 +58,6 @@ const settingsSlice = createSlice({
     initialState: initialIphoneState,
     reducers: {
         setDaysRange(state, action: PayloadAction<DaysRange>) {
-            console.log("daysRange")
             state.daysRange = action.payload
         },
         setStartTime(state, action: PayloadAction<Dayjs>) {
@@ -85,6 +86,9 @@ const settingsSlice = createSlice({
         },
         setDisplayTime(state, action: PayloadAction<boolean>) {
             state.displayTime = action.payload
+        },
+        setWidgets(state, action: PayloadAction<boolean>) {
+            state.widgets = action.payload
         },
         resetToDefault(state) {
             if (state.device === 'iphone') {

--- a/src/store/timetable-action.ts
+++ b/src/store/timetable-action.ts
@@ -1,5 +1,5 @@
 import { useSelector } from "react-redux";
-import { formatTimetableInfos } from "../utils/formatTimetable";
+import { formatTimetableInfos, generateTimetables } from "../utils/formatTimetable";
 import { timetableActions, timetableActionsType } from "./timetable-slice";
 import { settingsActions } from "./settings-slice";
 import { Dispatch } from "@reduxjs/toolkit";
@@ -13,12 +13,16 @@ export const getTimetable = (): ThunkAction<void, RootState, void, UpdateTimetab
     return (dispatch, getState) => {
         const state = getState();
         const coursesData = state.courses;
+        const device = state.settings.device;
         const daysRange = state.settings.daysRange;
         const startTime = state.settings.startTime;
         const endTime = state.settings.endTime;
+        const courseGridHeight = state.settings.courseGridHeight;
+        const pages = state.pages.pages;
 
-        const timetableInfos = formatTimetableInfos(coursesData, daysRange, startTime, endTime);
+        // const timetableInfos = formatTimetableInfos(coursesData, daysRange, startTime, endTime);
+        const timetables = generateTimetables(coursesData, daysRange, device, courseGridHeight, startTime, endTime, pages);
 
-        dispatch(timetableActions.updateTimetable(timetableInfos));
+        dispatch(timetableActions.updateTimetable(timetables));
     };
 };

--- a/src/store/timetable-slice.ts
+++ b/src/store/timetable-slice.ts
@@ -13,7 +13,7 @@ const initialDaysRange = {
 }
 
 
-const initialState = generateEmptyTimetableInfos(initialDaysRange, dayjs('2022-04-17T09:00'), dayjs('2022-04-17T18:00'))
+const initialState = [generateEmptyTimetableInfos(initialDaysRange, dayjs('2022-04-17T09:00'), dayjs('2022-04-17T18:00'))]
 
 
 const timetableSlice = createSlice({

--- a/src/utils/formatTimetable.ts
+++ b/src/utils/formatTimetable.ts
@@ -4,7 +4,7 @@ import { Dayjs } from "dayjs";
 import { CourseGridInfos } from "../components/Timetable/CourseGrid/CourseGrid";
 import { haveCourseGrid } from "../components/Timetable/TimetableTd/TimetableTd";
 import { DaysRange } from "../interfaces/settingsInterfaces";
-import { IPAD_LENGTH_LIMIT, IPHONE_LENGTH_LIMIT } from "../data/constants";
+import { Pages } from "../interfaces/pagesInterfaces"
 
 
 export function calculateCourseGridHeight(displayStartTime: Dayjs, displayEndTime: Dayjs) {
@@ -99,7 +99,6 @@ function findNotNullHour(timetableHours: timetableHours, hour: number): number {
 function addMeetingTimeToDay(timetableHours: timetableHours, meetingTime: meetingTime, courseCode: string, courseBackgroundColor: string, displayStartTime: Dayjs, displayEndTime: Dayjs): timetableHours {
     // Get the associating hour in timetableHours
     let hour = +displayStartTime.hour()
-    console.log("addMeetingTimeToDay" + hour)
 
     // If hour is null, then find previous hour that is not null
     if (timetableHours[hour as keyof timetableHours] === null) {
@@ -152,19 +151,27 @@ export function formatTimetableInfos(coursesData: courseInfo[], daysRange: DaysR
                     // && meetingTime.startTime >= startTime 
                     // && meetingTime.endTime <= endTime
                 ) {
-
-                    if (meetingTime.endTime > endTime) {
+                    console.log("start time" + startTime.hour())
+                    console.log("end time" + endTime.hour())
+                    console.log("meeting time start time" + meetingTime.startTime.hour())
+                    console.log("meeting time end time" + meetingTime.endTime.hour())
+                    if (meetingTime.startTime >= endTime || meetingTime.endTime <= startTime) {
+                        console.log("condition 1")
+                        continue
+                    }
+                    else if (meetingTime.endTime > endTime) {
+                        console.log("condition 2")
                         // meetingTime.endTime = endTime
-
                         timetableInfos[day as keyof timetableInfos] = addMeetingTimeToDay(timetableInfos[day as keyof timetableInfos]!, meetingTime, course.courseCode, course.backgroundColour, meetingTime.startTime, endTime)
                     }
-
                     else if (meetingTime.startTime < startTime) {
+                        console.log("condition 3")
                         // meetingTime.startTime = startTime
 
                         timetableInfos[day as keyof timetableInfos] = addMeetingTimeToDay(timetableInfos[day as keyof timetableInfos]!, meetingTime, course.courseCode, course.backgroundColour, startTime, meetingTime.endTime)
                     }
                     else {
+                        console.log("condition 4")
 
                         timetableInfos[day as keyof timetableInfos] = addMeetingTimeToDay(timetableInfos[day as keyof timetableInfos]!, meetingTime, course.courseCode, course.backgroundColour, meetingTime.startTime, meetingTime.endTime)
                     }
@@ -177,35 +184,15 @@ export function formatTimetableInfos(coursesData: courseInfo[], daysRange: DaysR
     return timetableInfos
 }
 
-export function generateTimetables(coursesData: courseInfo[], daysRange: DaysRange, device: string, courseGridHeight: number, startTime: Dayjs, endTime: Dayjs): timetableInfos[] {
-
+export function generateTimetables(coursesData: courseInfo[], daysRange: DaysRange, device: string, courseGridHeight: number, startTime: Dayjs, endTime: Dayjs, pages: Pages[]): timetableInfos[] {
     let timetables: timetableInfos[] = []
 
-    // 1. Set the limit
-    let limit;
-    device === "iphone" ? limit = IPHONE_LENGTH_LIMIT : limit = IPAD_LENGTH_LIMIT;
-
-    //2. Calculate number of rows
-    const numberOfRows = Math.floor(limit / courseGridHeight)
-
-    //3. Calculate pages startTime and endTime
-    const page1StartTime = startTime
-    const page1EndTime = startTime.add(numberOfRows, 'hour')
-
-    const page2StartTime = page1EndTime
-    const page2EndTime = endTime
-
-    //4. Generate timetables
-
-    timetables.push(formatTimetableInfos(coursesData, daysRange, page1StartTime, page1EndTime))
-    timetables.push(formatTimetableInfos(coursesData, daysRange, page2StartTime, page2EndTime))
+    for (const page of pages) {
+        const TimetableInfos = formatTimetableInfos(coursesData, daysRange, page.startTime, page.endTime)
+        timetables.push(TimetableInfos)
+    }
 
     return timetables
 
 
 }
-
-
-
-
-

--- a/src/utils/formatTimetable.ts
+++ b/src/utils/formatTimetable.ts
@@ -4,19 +4,20 @@ import { Dayjs } from "dayjs";
 import { CourseGridInfos } from "../components/Timetable/CourseGrid/CourseGrid";
 import { haveCourseGrid } from "../components/Timetable/TimetableTd/TimetableTd";
 import { DaysRange } from "../interfaces/settingsInterfaces";
+import { IPAD_LENGTH_LIMIT, IPHONE_LENGTH_LIMIT } from "../data/constants";
 
 
-export function calculateCourseGridHeight(meetingTime: meetingTime) {
+export function calculateCourseGridHeight(displayStartTime: Dayjs, displayEndTime: Dayjs) {
 
-    return meetingTime.endTime.diff(meetingTime.startTime, 'hour', true)
+    return displayEndTime.diff(displayStartTime, 'hour', true)
 }
 
 /* generateTimetableTdProps Helper function
  */
-function calculateRowSpan(courseGridInfos: CourseGridInfos[]): number {
+function calculateRowSpan(courseGridInfos: CourseGridInfos[], displayStartTime: Dayjs, displayEndTime: Dayjs): number {
 
-    const startTime = courseGridInfos[0].startTime;
-    const endTime = courseGridInfos[courseGridInfos.length - 1].endTime
+    const startTime = courseGridInfos[0].displayStartTime;
+    const endTime = courseGridInfos[courseGridInfos.length - 1].displayEndTime
     const duration = endTime.diff(startTime, 'hour', true)
 
     const rowspan = Math.ceil(startTime.minute() / 60 + duration)
@@ -26,7 +27,7 @@ function calculateRowSpan(courseGridInfos: CourseGridInfos[]): number {
 
 /* generateTimetableTdProps Helper function
  */
-export function generateCourseGridInfos(courseCode: string, courseBackgroundColor: string, meetingTime: meetingTime): CourseGridInfos {
+export function generateCourseGridInfos(courseCode: string, courseBackgroundColor: string, meetingTime: meetingTime, displayStartTime: Dayjs, displayEndTime: Dayjs): CourseGridInfos {
 
     const courseGridInfos: CourseGridInfos = {
         courseCode: courseCode,
@@ -35,8 +36,13 @@ export function generateCourseGridInfos(courseCode: string, courseBackgroundColo
         location: meetingTime.location,
         startTime: meetingTime.startTime,
         endTime: meetingTime.endTime,
-        height: calculateCourseGridHeight(meetingTime)
+        displayStartTime: displayStartTime,
+        displayEndTime: displayEndTime,
+        height: calculateCourseGridHeight(displayStartTime, displayEndTime)
     }
+    // console.log("startTime" + courseGridInfos.startTime.hour())
+    // console.log("displayTime" + displayStartTime.hour())
+    // console.log("height" + courseGridInfos.height)
 
     return courseGridInfos
 }
@@ -50,10 +56,10 @@ export function generateCourseGridInfos(courseCode: string, courseBackgroundColo
  * @param meetingTime
  * @param clockType 
  */
-function generateTimetableTdProps(oldTimetableTdProps: haveCourseGrid | null, courseCode: string, courseBackgroundColor: string, meetingTime: meetingTime): haveCourseGrid {
-    const courseGridInfo = generateCourseGridInfos(courseCode, courseBackgroundColor, meetingTime)
+function generateTimetableTdProps(oldTimetableTdProps: haveCourseGrid | null, courseCode: string, courseBackgroundColor: string, meetingTime: meetingTime, displayStartTime: Dayjs, displayEndTime: Dayjs): haveCourseGrid {
+    const courseGridInfo = generateCourseGridInfos(courseCode, courseBackgroundColor, meetingTime, displayStartTime, displayEndTime)
     const courseGridInfos = !oldTimetableTdProps ? [courseGridInfo] : [...oldTimetableTdProps.courseGridInfos, courseGridInfo]
-    const rowspan = calculateRowSpan(courseGridInfos)
+    const rowspan = calculateRowSpan(courseGridInfos, displayStartTime, displayEndTime)
 
     const timetableTdProps = {
         rowspan: rowspan,
@@ -61,7 +67,6 @@ function generateTimetableTdProps(oldTimetableTdProps: haveCourseGrid | null, co
     }
 
     return timetableTdProps
-
 }
 
 /* addMeetingTimeToDay Helper Function
@@ -91,9 +96,10 @@ function findNotNullHour(timetableHours: timetableHours, hour: number): number {
  * @param clockType
  * @returns coursesData: courses data with meetingTime.startTime and meetingTime.endTime in type Dayjs
 */
-function addMeetingTimeToDay(timetableHours: timetableHours, meetingTime: meetingTime, courseCode: string, courseBackgroundColor: string): timetableHours {
+function addMeetingTimeToDay(timetableHours: timetableHours, meetingTime: meetingTime, courseCode: string, courseBackgroundColor: string, displayStartTime: Dayjs, displayEndTime: Dayjs): timetableHours {
     // Get the associating hour in timetableHours
-    let hour = +meetingTime.startTime.hour()
+    let hour = +displayStartTime.hour()
+    console.log("addMeetingTimeToDay" + hour)
 
     // If hour is null, then find previous hour that is not null
     if (timetableHours[hour as keyof timetableHours] === null) {
@@ -107,7 +113,7 @@ function addMeetingTimeToDay(timetableHours: timetableHours, meetingTime: meetin
         throw new Error("timetableStartTime is Null")
     }
 
-    timetableStartTime.timetableTdProps = generateTimetableTdProps(timetableStartTime.timetableTdProps, courseCode, courseBackgroundColor, meetingTime)
+    timetableStartTime.timetableTdProps = generateTimetableTdProps(timetableStartTime.timetableTdProps, courseCode, courseBackgroundColor, meetingTime, displayStartTime, displayEndTime)
 
     if (!timetableStartTime.timetableTdProps.rowspan || !timetableStartTime.timetableTdProps.courseGridInfos) {
         throw new Error("timetableStartTime.timetableTdProps.rowspan is not defined")
@@ -127,7 +133,7 @@ function addMeetingTimeToDay(timetableHours: timetableHours, meetingTime: meetin
         i += 1
     }
     if (recalculateRowspan) {
-        timetableStartTime.timetableTdProps.rowspan = calculateRowSpan(timetableStartTime.timetableTdProps.courseGridInfos)
+        timetableStartTime.timetableTdProps.rowspan = calculateRowSpan(timetableStartTime.timetableTdProps.courseGridInfos, displayStartTime, displayEndTime)
     }
 
     return timetableHours
@@ -142,16 +148,61 @@ export function formatTimetableInfos(coursesData: courseInfo[], daysRange: DaysR
             for (const day in meetingTime.days) {
 
                 if (meetingTime.days[day as keyof typeof meetingTime.days] &&
-                    timetableInfos[day as keyof timetableInfos] &&
-                    meetingTime.startTime >= startTime &&
-                    meetingTime.endTime <= endTime) {
-                    timetableInfos[day as keyof timetableInfos] = addMeetingTimeToDay(timetableInfos[day as keyof timetableInfos]!, meetingTime, course.courseCode, course.backgroundColour)
+                    timetableInfos[day as keyof timetableInfos]
+                    // && meetingTime.startTime >= startTime 
+                    // && meetingTime.endTime <= endTime
+                ) {
+
+                    if (meetingTime.endTime > endTime) {
+                        // meetingTime.endTime = endTime
+
+                        timetableInfos[day as keyof timetableInfos] = addMeetingTimeToDay(timetableInfos[day as keyof timetableInfos]!, meetingTime, course.courseCode, course.backgroundColour, meetingTime.startTime, endTime)
+                    }
+
+                    else if (meetingTime.startTime < startTime) {
+                        // meetingTime.startTime = startTime
+
+                        timetableInfos[day as keyof timetableInfos] = addMeetingTimeToDay(timetableInfos[day as keyof timetableInfos]!, meetingTime, course.courseCode, course.backgroundColour, startTime, meetingTime.endTime)
+                    }
+                    else {
+
+                        timetableInfos[day as keyof timetableInfos] = addMeetingTimeToDay(timetableInfos[day as keyof timetableInfos]!, meetingTime, course.courseCode, course.backgroundColour, meetingTime.startTime, meetingTime.endTime)
+                    }
+
                 }
             }
         }
     }
 
     return timetableInfos
+}
+
+export function generateTimetables(coursesData: courseInfo[], daysRange: DaysRange, device: string, courseGridHeight: number, startTime: Dayjs, endTime: Dayjs): timetableInfos[] {
+
+    let timetables: timetableInfos[] = []
+
+    // 1. Set the limit
+    let limit;
+    device === "iphone" ? limit = IPHONE_LENGTH_LIMIT : limit = IPAD_LENGTH_LIMIT;
+
+    //2. Calculate number of rows
+    const numberOfRows = Math.floor(limit / courseGridHeight)
+
+    //3. Calculate pages startTime and endTime
+    const page1StartTime = startTime
+    const page1EndTime = startTime.add(numberOfRows, 'hour')
+
+    const page2StartTime = page1EndTime
+    const page2EndTime = endTime
+
+    //4. Generate timetables
+
+    timetables.push(formatTimetableInfos(coursesData, daysRange, page1StartTime, page1EndTime))
+    timetables.push(formatTimetableInfos(coursesData, daysRange, page2StartTime, page2EndTime))
+
+    return timetables
+
+
 }
 
 


### PR DESCRIPTION
**New Feature: Add Next Page**

This pull request introduces an enhancement to the timetable by adding support for a second page, specifically designed to accommodate longer durations and schedules. With the addition of the 'next page' property, the timetable becomes more versatile and user-friendly, allowing for a seamless user experience when dealing with extended timeframes.

**Changes Made**:
* Implemented navigation controls for switching between pages (adding Prev Button and Next Button next to device)
* Added page redux to store pages info
* Updated Timetable to render the next page component

**Testing**:
1. Select a startTime and endTime on the settings component, where the duration is longer then 1 page
2. Navigate to click the next button on the Timetable Component
3. The next page of the timetable is expected to be rendered.

**Screenshots**
<img width="582" alt="Screenshot 2023-10-16 at 5 33 27 PM" src="https://github.com/anitacheung83/Timetable-Wallpaper/assets/77123829/926393e0-5d4b-4438-988a-6b04746eceb8">
<img width="532" alt="Screenshot 2023-10-16 at 5 33 50 PM" src="https://github.com/anitacheung83/Timetable-Wallpaper/assets/77123829/c68a21b5-b1fd-4b46-a025-df7ccebccbb3">


**Checklists**
[ ]: Test has been added to test "new page" feature
[ ]: Documentation has been updated to reflect the new "next page" feature

 